### PR TITLE
feat: Hub-Router : Handle create connection request

### DIFF
--- a/cmd/hub-router/startcmd/start_test.go
+++ b/cmd/hub-router/startcmd/start_test.go
@@ -217,7 +217,7 @@ func TestGetStartCmd(t *testing.T) {
 			datasourceParams: &datasourceParams{},
 		}
 
-		err := addHandlers(parameters, nil, nil)
+		err := addHandlers(parameters, nil, nil, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "init persistent storage provider with url : invalid dbURL")
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ module github.com/trustbloc/hub-router
 go 1.15
 
 require (
+	github.com/google/uuid v1.1.1
 	github.com/hyperledger/aries-framework-go v0.1.5-0.20200918143342-09b3e884d06f
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect

--- a/pkg/aries/aries.go
+++ b/pkg/aries/aries.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/client/outofband"
 	ariescrypto "github.com/hyperledger/aries-framework-go/pkg/crypto"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
@@ -37,6 +38,7 @@ type OutOfBand interface {
 
 // DIDExchange client.
 type DIDExchange interface {
+	CreateConnection(myDID string, theirDID *did.Doc, options ...didexchange.ConnectionOption) (string, error)
 	RegisterActionEvent(chan<- service.DIDCommAction) error
 }
 

--- a/pkg/aries/msg_svc.go
+++ b/pkg/aries/msg_svc.go
@@ -1,0 +1,66 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package aries
+
+import "github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+
+// MsgService msg service implementation.
+type MsgService struct {
+	svcName string
+	purpose []string
+	msgType string
+	msgCh   chan service.DIDCommMsg
+}
+
+// NewMsgSvc new msg service.
+func NewMsgSvc(name, msgType, purpose string, msgCh chan service.DIDCommMsg) *MsgService {
+	return &MsgService{
+		svcName: name,
+		msgType: msgType,
+		purpose: []string{purpose},
+		msgCh:   msgCh,
+	}
+}
+
+// Name svc name.
+func (m *MsgService) Name() string {
+	return m.svcName
+}
+
+// Accept validates whether the service handles msgType and purpose.
+func (m *MsgService) Accept(msgType string, purpose []string) bool {
+	purposeMatched, typeMatched := len(m.purpose) == 0, m.msgType == ""
+
+	if purposeMatched && typeMatched {
+		return false
+	}
+
+	for _, purposeCriteria := range m.purpose {
+		for _, msgPurpose := range purpose {
+			if purposeCriteria == msgPurpose {
+				purposeMatched = true
+
+				break
+			}
+		}
+	}
+
+	if m.msgType == msgType {
+		typeMatched = true
+	}
+
+	return purposeMatched && typeMatched
+}
+
+// HandleInbound handles inbound didcomm msg.
+func (m *MsgService) HandleInbound(msg service.DIDCommMsg, _, _ string) (string, error) {
+	go func() {
+		m.msgCh <- msg
+	}()
+
+	return "", nil
+}

--- a/pkg/aries/msg_svc_test.go
+++ b/pkg/aries/msg_svc_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package aries
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMsgSvc(t *testing.T) {
+	name := "msg-123"
+	msgType := "http://example.com/message/test"
+	purpose := "msg-123"
+	msgCh := make(chan service.DIDCommMsg)
+
+	msgSvc := NewMsgSvc(name, msgType, purpose, msgCh)
+	require.Equal(t, name, msgSvc.Name())
+
+	require.True(t, msgSvc.Accept(msgType, []string{purpose, "purpose2"}))
+	require.False(t, msgSvc.Accept(purpose, []string{purpose}))
+	require.False(t, msgSvc.Accept(msgType, []string{"purpose2"}))
+	require.False(t, msgSvc.Accept("", nil))
+
+	done := make(chan struct{})
+
+	go func() {
+		<-msgCh
+		done <- struct{}{}
+	}()
+
+	msg := service.NewDIDCommMsgMap(struct {
+		Type string `json:"@type,omitempty"`
+	}{Type: msgType})
+
+	_, err := msgSvc.HandleInbound(msg, "", "")
+	require.NoError(t, err)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "tests are not validated due to timeout")
+	}
+}

--- a/pkg/internal/mock/didexchange/client.go
+++ b/pkg/internal/mock/didexchange/client.go
@@ -7,14 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 package didexchange
 
 import (
+	"github.com/google/uuid"
 	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 )
 
 // MockClient is a mock didexchange.MockClient used in tests.
 type MockClient struct {
-	ActionEventFunc     func(chan<- service.DIDCommAction) error
-	CreateInvitationErr error
+	ActionEventFunc func(chan<- service.DIDCommAction) error
+	CreateConnErr   error
 }
 
 // RegisterActionEvent registers the action event channel.
@@ -26,11 +28,11 @@ func (c *MockClient) RegisterActionEvent(actions chan<- service.DIDCommAction) e
 	return nil
 }
 
-// CreateInvitation creates an explicit invitation.
-func (c *MockClient) CreateInvitation(label string) (*didexchange.Invitation, error) {
-	if c.CreateInvitationErr != nil {
-		return nil, c.CreateInvitationErr
+// CreateConnection creates connection.
+func (c *MockClient) CreateConnection(_ string, _ *did.Doc, _ ...didexchange.ConnectionOption) (string, error) {
+	if c.CreateConnErr != nil {
+		return "", c.CreateConnErr
 	}
 
-	return &didexchange.Invitation{}, nil
+	return uuid.New().String(), nil
 }

--- a/pkg/internal/mock/messenger/messenger.go
+++ b/pkg/internal/mock/messenger/messenger.go
@@ -1,0 +1,40 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package messenger
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+)
+
+// MockMessenger mock messenger.
+type MockMessenger struct {
+	ReplyToFunc func(msgID string, msg service.DIDCommMsgMap) error
+}
+
+// ReplyTo reply to a message.
+func (m *MockMessenger) ReplyTo(msgID string, msg service.DIDCommMsgMap) error {
+	if m.ReplyToFunc != nil {
+		return m.ReplyToFunc(msgID, msg)
+	}
+
+	return nil
+}
+
+// Send send message.
+func (m *MockMessenger) Send(_ service.DIDCommMsgMap, _, _ string) error {
+	return nil
+}
+
+// SendToDestination send mesage to destination.
+func (m *MockMessenger) SendToDestination(_ service.DIDCommMsgMap, _ string, _ *service.Destination) error {
+	return nil
+}
+
+// ReplyToNested reply to nested message.
+func (m *MockMessenger) ReplyToNested(_ string, _ service.DIDCommMsgMap, _, _ string) error {
+	return nil
+}

--- a/pkg/restapi/operation/models.go
+++ b/pkg/restapi/operation/models.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package operation
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/hyperledger/aries-framework-go/pkg/client/outofband"
@@ -20,4 +21,31 @@ type healthCheckResp struct {
 // DIDCommInvitationResp model.
 type DIDCommInvitationResp struct {
 	Invitation *outofband.Invitation `json:"invitation"`
+}
+
+// CreateConnReq model.
+type CreateConnReq struct {
+	ID      string             `json:"@id"`
+	Type    string             `json:"@type"`
+	Purpose []string           `json:"~purpose"`
+	Data    *CreateConnReqData `json:"data"`
+}
+
+// CreateConnReqData model for data in CreateConnReq.
+type CreateConnReqData struct {
+	DIDDoc json.RawMessage `json:"thirdPartyDIDDoc"`
+}
+
+// CreateConnResp model.
+type CreateConnResp struct {
+	ID      string              `json:"@id"`
+	Type    string              `json:"@type"`
+	Purpose []string            `json:"~purpose"`
+	Data    *CreateConnRespData `json:"data"`
+}
+
+// CreateConnRespData model for error data in CreateConnResp.
+type CreateConnRespData struct {
+	ErrorMsg string          `json:"errorMsg"`
+	DIDDoc   json.RawMessage `json:"routerDIDDoc"`
 }

--- a/pkg/restapi/operation/support_test.go
+++ b/pkg/restapi/operation/support_test.go
@@ -9,6 +9,7 @@ package operation
 import (
 	"fmt"
 
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/messaging/msghandler"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
 	outofbandsvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/outofband"
@@ -43,7 +44,8 @@ func getAriesCtx() aries.Ctx {
 
 func config() *Config {
 	return &Config{
-		Aries: getAriesCtx(),
+		Aries:        getAriesCtx(),
+		MsgRegistrar: msghandler.NewRegistrar(),
 		Storage: &Storage{
 			Persistent: memstore.NewProvider(),
 			Transient:  memstore.NewProvider(),


### PR DESCRIPTION
The Purpose decorator/message service is used to pass the messages for creating a connection request.

Actions:
- Router validates the DIDDoc in the request.
- Creates a new PeerDID Doc
- Creates connection
- Sends the routers new PeerDID doc in the response

closes #26 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>