### PR TITLE
chore: Update Aries Framework Go

### DIFF
--- a/cmd/hub-router/go.mod
+++ b/cmd/hub-router/go.mod
@@ -9,7 +9,7 @@ go 1.15
 require (
 	github.com/cenkalti/backoff/v4 v4.0.2
 	github.com/gorilla/mux v1.7.4
-	github.com/hyperledger/aries-framework-go v0.1.5-0.20200918143342-09b3e884d06f
+	github.com/hyperledger/aries-framework-go v0.1.5-0.20201002141934-47a2ea3afd67
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v1.0.0

--- a/cmd/hub-router/go.sum
+++ b/cmd/hub-router/go.sum
@@ -126,8 +126,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20200918143342-09b3e884d06f h1:+UZr7AH1TFgvBO73c4ueXqQZinw+0KVzwo0cFdqWgQQ=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20200918143342-09b3e884d06f/go.mod h1:lZAo9af+3VCHzShhGhPizGcs+927moWea9u1QPp75tU=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201002141934-47a2ea3afd67 h1:Ejp3iUY3Y67dgP90TYKisDzAbVU5oo2/BlRSgMZwxLQ=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201002141934-47a2ea3afd67/go.mod h1:lZAo9af+3VCHzShhGhPizGcs+927moWea9u1QPp75tU=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ go 1.15
 
 require (
 	github.com/google/uuid v1.1.1
-	github.com/hyperledger/aries-framework-go v0.1.5-0.20200918143342-09b3e884d06f
+	github.com/hyperledger/aries-framework-go v0.1.5-0.20201002141934-47a2ea3afd67
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/onsi/ginkgo v1.10.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20200918143342-09b3e884d06f h1:+UZr7AH1TFgvBO73c4ueXqQZinw+0KVzwo0cFdqWgQQ=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20200918143342-09b3e884d06f/go.mod h1:lZAo9af+3VCHzShhGhPizGcs+927moWea9u1QPp75tU=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201002141934-47a2ea3afd67 h1:Ejp3iUY3Y67dgP90TYKisDzAbVU5oo2/BlRSgMZwxLQ=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201002141934-47a2ea3afd67/go.mod h1:lZAo9af+3VCHzShhGhPizGcs+927moWea9u1QPp75tU=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a h1:zPPuIq2jAWWPTrGt70eK/BSch+gFAGrNzecsoENgu2o=

--- a/pkg/internal/mock/outofband/service.go
+++ b/pkg/internal/mock/outofband/service.go
@@ -37,12 +37,13 @@ func (m *MockService) UnregisterMsgEvent(ch chan<- service.StateMsg) error {
 }
 
 // AcceptRequest mock.
-func (m *MockService) AcceptRequest(request *outofband.Request, s string) (string, error) {
+func (m *MockService) AcceptRequest(request *outofband.Request, s string, routerConnections []string) (string, error) {
 	panic("not implemented")
 }
 
 // AcceptInvitation mock.
-func (m *MockService) AcceptInvitation(invitation *outofband.Invitation, s string) (string, error) {
+func (m *MockService) AcceptInvitation(invitation *outofband.Invitation, s string,
+	routerConnections []string) (string, error) {
 	panic("not implemented")
 }
 

--- a/pkg/restapi/operation/operation.go
+++ b/pkg/restapi/operation/operation.go
@@ -236,7 +236,7 @@ func (o *Operation) handleCreateConnReq(msg service.DIDCommMsg) (service.DIDComm
 	}
 
 	// create peer DID
-	newDidDoc, err := o.vdriRegistry.Create("peer", vdri.WithServiceEndpoint(""))
+	newDidDoc, err := o.vdriRegistry.Create("peer", vdri.WithDefaultServiceEndpoint(""))
 	if err != nil {
 		return nil, fmt.Errorf("create new peer did : %w", err)
 	}

--- a/test/bdd/fixtures/integration/.env
+++ b/test/bdd/fixtures/integration/.env
@@ -6,7 +6,7 @@
 
 # Aries Agent configurations
 ARIES_AGENT_REST_IMAGE=docker.pkg.github.com/trustbloc-cicd/aries-framework-go/agent-rest
-ARIES_AGENT_REST_IMAGE_TAG=amd64-0.1.5-snapshot-53f73dc
+ARIES_AGENT_REST_IMAGE_TAG=amd64-0.1.5-snapshot-47a2ea3
 
 # configs
 HTTP_SCHEME=http

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.0.2
 	github.com/cucumber/godog v0.9.0
 	github.com/fsouza/go-dockerclient v1.6.5
-	github.com/hyperledger/aries-framework-go v0.1.5-0.20200918143342-09b3e884d06f
+	github.com/hyperledger/aries-framework-go v0.1.5-0.20201002141934-47a2ea3afd67
 	github.com/trustbloc/edge-core v0.1.5-0.20200916124536-c32454a16108
 	github.com/trustbloc/hub-router v0.0.0-00010101000000-000000000000
 )

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -179,8 +179,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20200918143342-09b3e884d06f h1:+UZr7AH1TFgvBO73c4ueXqQZinw+0KVzwo0cFdqWgQQ=
-github.com/hyperledger/aries-framework-go v0.1.5-0.20200918143342-09b3e884d06f/go.mod h1:lZAo9af+3VCHzShhGhPizGcs+927moWea9u1QPp75tU=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201002141934-47a2ea3afd67 h1:Ejp3iUY3Y67dgP90TYKisDzAbVU5oo2/BlRSgMZwxLQ=
+github.com/hyperledger/aries-framework-go v0.1.5-0.20201002141934-47a2ea3afd67/go.mod h1:lZAo9af+3VCHzShhGhPizGcs+927moWea9u1QPp75tU=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a h1:zPPuIq2jAWWPTrGt70eK/BSch+gFAGrNzecsoENgu2o=

--- a/test/bdd/pkg/router/router_steps.go
+++ b/test/bdd/pkg/router/router_steps.go
@@ -98,7 +98,7 @@ func (e *Steps) invitation() error {
 }
 
 func (e *Steps) connectWithRouter() error {
-	err := e.connect(e.routerInvitationStr)
+	err := e.connect(e.routerInvitationStr, "")
 	if err != nil {
 		return fmt.Errorf("connect with router : %w", err)
 	}
@@ -107,7 +107,7 @@ func (e *Steps) connectWithRouter() error {
 }
 
 func (e *Steps) connectWithAdapter() error {
-	err := e.connect(e.adapterInvitationStr)
+	err := e.connect(e.adapterInvitationStr, e.routerConnID)
 	if err != nil {
 		return fmt.Errorf("connect with adapter : %w", err)
 	}
@@ -115,9 +115,9 @@ func (e *Steps) connectWithAdapter() error {
 	return nil
 }
 
-func (e *Steps) connect(invitation *outofband.Invitation) error {
+func (e *Steps) connect(invitation *outofband.Invitation, routerConnID string) error {
 	// receive invitation
-	connID, err := e.receiveInvitation(invitation)
+	connID, err := e.receiveInvitation(invitation, routerConnID)
 	if err != nil {
 		return fmt.Errorf("receive inviation : %w", err)
 	}
@@ -184,10 +184,11 @@ func (e *Steps) adapterInvitation() error {
 	return nil
 }
 
-func (e *Steps) receiveInvitation(invitation *outofband.Invitation) (string, error) {
+func (e *Steps) receiveInvitation(invitation *outofband.Invitation, routerConnID string) (string, error) {
 	req := oobcmd.AcceptInvitationArgs{
-		Invitation: invitation,
-		MyLabel:    "wallet",
+		Invitation:        invitation,
+		MyLabel:           "wallet",
+		RouterConnections: routerConnID,
 	}
 
 	reqBytes, err := json.Marshal(req)


### PR DESCRIPTION
Multiple router support was added to AFG and few APIs were broken. Updated Hub-Router code to support the changes.

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>