### PR TITLE
feat:  Docker adds ca-certificate

### DIFF
--- a/images/hub-router/Dockerfile
+++ b/images/hub-router/Dockerfile
@@ -15,7 +15,7 @@ RUN make hub-router
 
 FROM alpine:${ALPINE_VER}
 COPY --from=base /go/src/github.com/trustbloc/hub-router/.build/bin/hub-router /usr/local/bin
-
+RUN apk add -U --no-cache ca-certificates
 # set up nsswitch.conf for Go's "netgo" implementation
 # - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf

--- a/test/bdd/fixtures/hub-router/docker-compose.yml
+++ b/test/bdd/fixtures/hub-router/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - ${HUB_ROUTER_DIDCOMM_HTTP_PORT}:${HUB_ROUTER_DIDCOMM_HTTP_PORT}
       - ${HUB_ROUTER_DIDCOMM_WS_PORT}:${HUB_ROUTER_DIDCOMM_WS_PORT}
     entrypoint: ""
-    command: /bin/sh -c "hub-router start"
+    command: /bin/sh -c "cp /etc/tls/* /usr/local/share/ca-certificates/;update-ca-certificates; hub-router start"
     volumes:
       - ../keys/tls:/etc/tls
     depends_on:


### PR DESCRIPTION
Adds ca-certificate.

Issue: When we communicate between two services(in docker) there is a problem with invalid certs. This change makes the certs `trustable`.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>